### PR TITLE
Fixed Shadow Radiance armor not having UUIDs in 1.20.1

### DIFF
--- a/src/main/java/fr/iglee42/createqualityoflife/items/ShadowRadianceArmorItem.java
+++ b/src/main/java/fr/iglee42/createqualityoflife/items/ShadowRadianceArmorItem.java
@@ -42,13 +42,12 @@ public class ShadowRadianceArmorItem extends BaseArmorItem {
             ImmutableMultimap.Builder<Attribute, AttributeModifier> attributes = ImmutableMultimap.builder();
             attributes.putAll(super.getDefaultAttributeModifiers(p_40390_));
 			
-			String reference = "shadow_radiance_"+p_40390_.name().toLowerCase();
+            String reference = "shadow_radiance_"+p_40390_.name().toLowerCase();	
+            UUID uuidBlock = UUID.nameUUIDFromBytes((reference+"_block").getBytes());
+            UUID uuidEntity = UUID.nameUUIDFromBytes((reference+"_entity").getBytes());
 			
-			UUID block_uuid = UUID.nameUUIDFromBytes((reference+"_block").getBytes());
-			UUID entity_uuid = UUID.nameUUIDFromBytes((reference+"_entity").getBytes());
-			
-            attributes.put(ForgeMod.BLOCK_REACH.get(), new AttributeModifier(block_uuid,reference+"_block",1, AttributeModifier.Operation.ADDITION));
-            attributes.put(ForgeMod.ENTITY_REACH.get(), new AttributeModifier(entity_uuid,reference+"_entity",1, AttributeModifier.Operation.ADDITION));
+            attributes.put(ForgeMod.BLOCK_REACH.get(), new AttributeModifier(uuidBlock,reference+"_block",1, AttributeModifier.Operation.ADDITION));
+            attributes.put(ForgeMod.ENTITY_REACH.get(), new AttributeModifier(uuidEntity,reference+"_entity",1, AttributeModifier.Operation.ADDITION));
             return attributes.build();
         }
         return super.getDefaultAttributeModifiers(p_40390_);

--- a/src/main/java/fr/iglee42/createqualityoflife/items/ShadowRadianceArmorItem.java
+++ b/src/main/java/fr/iglee42/createqualityoflife/items/ShadowRadianceArmorItem.java
@@ -17,6 +17,7 @@ import net.minecraft.world.item.ArmorMaterial;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraftforge.common.ForgeMod;
+import java.util.UUID;
 
 public class ShadowRadianceArmorItem extends BaseArmorItem {
     public ShadowRadianceArmorItem(ArmorMaterial armorMaterial, Type type, Properties properties, ResourceLocation textureLoc) {
@@ -40,8 +41,14 @@ public class ShadowRadianceArmorItem extends BaseArmorItem {
         if (p_40390_.equals(getEquipmentSlot())){
             ImmutableMultimap.Builder<Attribute, AttributeModifier> attributes = ImmutableMultimap.builder();
             attributes.putAll(super.getDefaultAttributeModifiers(p_40390_));
-            attributes.put(ForgeMod.BLOCK_REACH.get(), new AttributeModifier("shadow_radiance_"+p_40390_.name().toLowerCase()+"_block",1, AttributeModifier.Operation.ADDITION));
-            attributes.put(ForgeMod.ENTITY_REACH.get(), new AttributeModifier("shadow_radiance_"+p_40390_.name().toLowerCase()+"_entity",1, AttributeModifier.Operation.ADDITION));
+			
+			String reference = "shadow_radiance_"+p_40390_.name().toLowerCase();
+			
+			UUID block_uuid = UUID.nameUUIDFromBytes((reference+"_block").getBytes());
+			UUID entity_uuid = UUID.nameUUIDFromBytes((reference+"_entity").getBytes());
+			
+            attributes.put(ForgeMod.BLOCK_REACH.get(), new AttributeModifier(block_uuid,reference+"_block",1, AttributeModifier.Operation.ADDITION));
+            attributes.put(ForgeMod.ENTITY_REACH.get(), new AttributeModifier(entity_uuid,reference+"_entity",1, AttributeModifier.Operation.ADDITION));
             return attributes.build();
         }
         return super.getDefaultAttributeModifiers(p_40390_);

--- a/src/main/java/fr/iglee42/createqualityoflife/items/ShadowRadianceChestplate.java
+++ b/src/main/java/fr/iglee42/createqualityoflife/items/ShadowRadianceChestplate.java
@@ -30,6 +30,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
 import java.util.function.Supplier;
+import java.util.UUID;
 
 public class ShadowRadianceChestplate extends BacktankItem.Layered{
 
@@ -43,12 +44,18 @@ public class ShadowRadianceChestplate extends BacktankItem.Layered{
 
 
     @Override
-    public Multimap<Attribute, AttributeModifier> getDefaultAttributeModifiers(EquipmentSlot p_40390_) {
+	public Multimap<Attribute, AttributeModifier> getDefaultAttributeModifiers(EquipmentSlot p_40390_) {
         if (p_40390_.equals(EquipmentSlot.CHEST)){
             ImmutableMultimap.Builder<Attribute, AttributeModifier> attributes = ImmutableMultimap.builder();
             attributes.putAll(super.getDefaultAttributeModifiers(p_40390_));
-            attributes.put(ForgeMod.BLOCK_REACH.get(), new AttributeModifier("shadow_radiance_"+p_40390_.name().toLowerCase()+"_block",1, AttributeModifier.Operation.ADDITION));
-            attributes.put(ForgeMod.ENTITY_REACH.get(), new AttributeModifier("shadow_radiance_"+p_40390_.name().toLowerCase()+"_entity",1, AttributeModifier.Operation.ADDITION));
+			
+			String reference = "shadow_radiance_"+p_40390_.name().toLowerCase();
+			
+			UUID block_uuid = UUID.nameUUIDFromBytes((reference+"_block").getBytes());
+			UUID entity_uuid = UUID.nameUUIDFromBytes((reference+"_entity").getBytes());
+			
+            attributes.put(ForgeMod.BLOCK_REACH.get(), new AttributeModifier(block_uuid,reference+"_block",1, AttributeModifier.Operation.ADDITION));
+            attributes.put(ForgeMod.ENTITY_REACH.get(), new AttributeModifier(entity_uuid,reference+"_entity",1, AttributeModifier.Operation.ADDITION));
             return attributes.build();
         }
         return super.getDefaultAttributeModifiers(p_40390_);

--- a/src/main/java/fr/iglee42/createqualityoflife/items/ShadowRadianceChestplate.java
+++ b/src/main/java/fr/iglee42/createqualityoflife/items/ShadowRadianceChestplate.java
@@ -48,14 +48,13 @@ public class ShadowRadianceChestplate extends BacktankItem.Layered{
         if (p_40390_.equals(EquipmentSlot.CHEST)){
             ImmutableMultimap.Builder<Attribute, AttributeModifier> attributes = ImmutableMultimap.builder();
             attributes.putAll(super.getDefaultAttributeModifiers(p_40390_));
-			
-			String reference = "shadow_radiance_"+p_40390_.name().toLowerCase();
-			
-			UUID block_uuid = UUID.nameUUIDFromBytes((reference+"_block").getBytes());
-			UUID entity_uuid = UUID.nameUUIDFromBytes((reference+"_entity").getBytes());
-			
-            attributes.put(ForgeMod.BLOCK_REACH.get(), new AttributeModifier(block_uuid,reference+"_block",1, AttributeModifier.Operation.ADDITION));
-            attributes.put(ForgeMod.ENTITY_REACH.get(), new AttributeModifier(entity_uuid,reference+"_entity",1, AttributeModifier.Operation.ADDITION));
+
+            String reference = "shadow_radiance_"+p_40390_.name().toLowerCase();	
+            UUID uuidBlock = UUID.nameUUIDFromBytes((reference+"_block").getBytes());
+            UUID uuidEntity = UUID.nameUUIDFromBytes((reference+"_entity").getBytes());
+
+            attributes.put(ForgeMod.BLOCK_REACH.get(), new AttributeModifier(uuidBlock,reference+"_block",1, AttributeModifier.Operation.ADDITION));
+            attributes.put(ForgeMod.ENTITY_REACH.get(), new AttributeModifier(uuidEntity,reference+"_entity",1, AttributeModifier.Operation.ADDITION));
             return attributes.build();
         }
         return super.getDefaultAttributeModifiers(p_40390_);

--- a/src/main/java/fr/iglee42/createqualityoflife/items/ShadowRadianceHelmet.java
+++ b/src/main/java/fr/iglee42/createqualityoflife/items/ShadowRadianceHelmet.java
@@ -45,14 +45,13 @@ public class ShadowRadianceHelmet extends DivingHelmetItem {
         if (p_40390_.equals(EquipmentSlot.HEAD)){
             ImmutableMultimap.Builder<Attribute, AttributeModifier> attributes = ImmutableMultimap.builder();
             attributes.putAll(super.getDefaultAttributeModifiers(p_40390_));
-			
-			String reference = "shadow_radiance_"+p_40390_.name().toLowerCase();
-			
-			UUID block_uuid = UUID.nameUUIDFromBytes((reference+"_block").getBytes());
-			UUID entity_uuid = UUID.nameUUIDFromBytes((reference+"_entity").getBytes());
-			
-            attributes.put(ForgeMod.BLOCK_REACH.get(), new AttributeModifier(block_uuid,reference+"_block",1, AttributeModifier.Operation.ADDITION));
-            attributes.put(ForgeMod.ENTITY_REACH.get(), new AttributeModifier(entity_uuid,reference+"_entity",1, AttributeModifier.Operation.ADDITION));
+
+            String reference = "shadow_radiance_"+p_40390_.name().toLowerCase();	
+            UUID uuidBlock = UUID.nameUUIDFromBytes((reference+"_block").getBytes());
+            UUID uuidEntity = UUID.nameUUIDFromBytes((reference+"_entity").getBytes());
+
+            attributes.put(ForgeMod.BLOCK_REACH.get(), new AttributeModifier(uuidBlock,reference+"_block",1, AttributeModifier.Operation.ADDITION));
+            attributes.put(ForgeMod.ENTITY_REACH.get(), new AttributeModifier(uuidEntity,reference+"_entity",1, AttributeModifier.Operation.ADDITION));
             return attributes.build();
         }
         return super.getDefaultAttributeModifiers(p_40390_);

--- a/src/main/java/fr/iglee42/createqualityoflife/items/ShadowRadianceHelmet.java
+++ b/src/main/java/fr/iglee42/createqualityoflife/items/ShadowRadianceHelmet.java
@@ -21,6 +21,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.DispenserBlock;
 import net.minecraftforge.common.ForgeMod;
+import java.util.UUID;
 
 public class ShadowRadianceHelmet extends DivingHelmetItem {
     public ShadowRadianceHelmet(ArmorMaterial material, Properties properties, ResourceLocation textureLoc) {
@@ -44,8 +45,14 @@ public class ShadowRadianceHelmet extends DivingHelmetItem {
         if (p_40390_.equals(EquipmentSlot.HEAD)){
             ImmutableMultimap.Builder<Attribute, AttributeModifier> attributes = ImmutableMultimap.builder();
             attributes.putAll(super.getDefaultAttributeModifiers(p_40390_));
-            attributes.put(ForgeMod.BLOCK_REACH.get(), new AttributeModifier("shadow_radiance_"+p_40390_.name().toLowerCase()+"_block",1, AttributeModifier.Operation.ADDITION));
-            attributes.put(ForgeMod.ENTITY_REACH.get(), new AttributeModifier("shadow_radiance_"+p_40390_.name().toLowerCase()+"_entity",1, AttributeModifier.Operation.ADDITION));
+			
+			String reference = "shadow_radiance_"+p_40390_.name().toLowerCase();
+			
+			UUID block_uuid = UUID.nameUUIDFromBytes((reference+"_block").getBytes());
+			UUID entity_uuid = UUID.nameUUIDFromBytes((reference+"_entity").getBytes());
+			
+            attributes.put(ForgeMod.BLOCK_REACH.get(), new AttributeModifier(block_uuid,reference+"_block",1, AttributeModifier.Operation.ADDITION));
+            attributes.put(ForgeMod.ENTITY_REACH.get(), new AttributeModifier(entity_uuid,reference+"_entity",1, AttributeModifier.Operation.ADDITION));
             return attributes.build();
         }
         return super.getDefaultAttributeModifiers(p_40390_);


### PR DESCRIPTION
Fixes issue https://github.com/iglee42/CreateQualityOfLife/issues/24, that causes the block reach and entity reach to not be directly linked to the armor, causing it to keep adding up.


![image](https://github.com/user-attachments/assets/2013806d-8b97-4ec2-8cac-6c047c8bbc20)
