### PR TITLE
Try Fix Issues #38

### DIFF
--- a/src/main/java/fr/iglee42/createqualityoflife/items/armors/RefinedRadianceHelmet.java
+++ b/src/main/java/fr/iglee42/createqualityoflife/items/armors/RefinedRadianceHelmet.java
@@ -68,7 +68,7 @@ public class RefinedRadianceHelmet extends DivingHelmetItem implements QOLConfig
 
     @Override
     public int effectTime(ItemStack stack) {
-        return 200;
+        return 220;
     }
 
     @Override

--- a/src/main/java/fr/iglee42/createqualityoflife/items/armors/ShadowRadianceHelmet.java
+++ b/src/main/java/fr/iglee42/createqualityoflife/items/armors/ShadowRadianceHelmet.java
@@ -96,7 +96,7 @@ public class ShadowRadianceHelmet extends DivingHelmetItem implements QOLConfigu
 
     @Override
     public int effectTime(ItemStack stack) {
-        return 200;
+        return 220;
     }
 
     @Override


### PR DESCRIPTION
## What
I adjusted the night vision effect duration from 200 ticks to 220 ticks in both places.

## Why
When the effect duration is exactly 200 ticks, it refreshes right at 199 ticks, which triggers the flickering loop. Increasing the duration slightly above 10 seconds prevents the timer from entering that flicker threshold.

## Fix
This minimal and low-risk change completely eliminates the flickering issue reported in #38 .