### PR TITLE
Toggle between fans and elytra

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,6 @@
+------------------------------------------------------
+CreateQualityOfLife 1.6.2
+------------------------------------------------------
+
+#### Gameplay Changes
+ - Added a new key to toggle between fans and elytra.

--- a/src/main/java/fr/iglee42/createqualityoflife/CreateQOLClient.java
+++ b/src/main/java/fr/iglee42/createqualityoflife/CreateQOLClient.java
@@ -118,6 +118,7 @@ public class CreateQOLClient {
         event.register(KeyBindManager.FANS_KEY);
         event.register(KeyBindManager.HOVER_KEY);
         event.register(KeyBindManager.ELYTRA_KEY);
+        event.register(KeyBindManager.TOGGLE_FANS_ELYTRA_KEY);
         event.register(KeyBindManager.OPEN_ARMOR_CONFIG);
         event.register(KeyBindManager.DASH_KEY);
 

--- a/src/main/java/fr/iglee42/createqualityoflife/items/armors/ShadowRadianceChestplate.java
+++ b/src/main/java/fr/iglee42/createqualityoflife/items/armors/ShadowRadianceChestplate.java
@@ -267,6 +267,35 @@ public class ShadowRadianceChestplate extends BacktankItem.Layered implements QO
         boolean elytra = isElytraEnable(chestplate);
         p.displayClientMessage(CreateQOLLang.translateDirect("ability.armor.toggle_message", CreateQOLLang.translateDirect("ability.armor.elytra_mode").getString()).append(QOLConfigurableItem.chooseState(true,true,elytra,false,true)).withStyle(elytra ? ChatFormatting.GREEN : ChatFormatting.RED),true);
     }
+
+    public static void toggleFansElytra(ItemStack chestplate,Player p) {
+        /* This method toggle beween the fans and elytra mode
+         * If both are present on the chestplate, it will toggle between the two modes
+         * If only one is present, it will toggle that mode
+         * If none are present, it will do nothing
+         * @param chestplate The chestplate to toggle
+         * @param p The player who is toggling
+         */
+        boolean hasElytra = hasElytra(chestplate);
+        boolean hasPropeller = hasPropeller(chestplate);
+
+        if (hasElytra && hasPropeller) {
+            if (!isFansEnable(chestplate) && !isElytraEnable(chestplate)) {
+                toggleFans(chestplate, p);
+            } else if (isElytraEnable(chestplate)) {
+                toggleElytra(chestplate, p);
+                toggleFans(chestplate, p);
+            } else if (isFansEnable(chestplate)) {
+                toggleFans(chestplate, p);
+                toggleElytra(chestplate, p);
+            }
+        } else if (hasElytra) {
+            toggleElytra(chestplate, p);
+        } else if (hasPropeller) {
+            toggleFans(chestplate, p);
+        }
+    }
+
     public static boolean hasPropeller(ItemStack chestplate){
         return chestplate.has(QOLDataComponents.BACKTANK_PROPELLERS) && Boolean.TRUE.equals(chestplate.get(QOLDataComponents.BACKTANK_PROPELLERS));
     }

--- a/src/main/java/fr/iglee42/createqualityoflife/packets/ToggleFansElytraPacket.java
+++ b/src/main/java/fr/iglee42/createqualityoflife/packets/ToggleFansElytraPacket.java
@@ -1,0 +1,42 @@
+package fr.iglee42.createqualityoflife.packets;
+
+import com.simibubi.create.content.equipment.armor.BacktankItem;
+import fr.iglee42.createqualityoflife.CreateQOLLang;
+import fr.iglee42.createqualityoflife.items.armors.ShadowRadianceChestplate;
+import fr.iglee42.createqualityoflife.registries.QOLItems;
+import fr.iglee42.createqualityoflife.registries.QOLPackets;
+import net.createmod.catnip.net.base.ServerboundPacketPayload;
+import net.minecraft.ChatFormatting;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.EquipmentSlot;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+
+public class ToggleFansElytraPacket implements ServerboundPacketPayload {
+
+    public static final ToggleFansElytraPacket INSTANCE = new ToggleFansElytraPacket();
+    public static final StreamCodec<FriendlyByteBuf,ToggleFansElytraPacket> STREAM_CODEC = StreamCodec.unit(INSTANCE);
+
+
+    @Override
+    public void handle(ServerPlayer player) {
+            if (player != null) {
+                ItemStack chestplate = player.getItemBySlot(EquipmentSlot.CHEST);
+                Item backtank = BacktankItem.getWornBy(player);
+
+                if (backtank == null) return;
+                if (QOLItems.SHADOW_RADIANCE_CHESTPLATE.is(backtank) && (ShadowRadianceChestplate.hasPropeller(chestplate) || ShadowRadianceChestplate.hasElytra(chestplate))) {
+                    ShadowRadianceChestplate.toggleFansElytra(chestplate,player);
+                }else if (QOLItems.SHADOW_RADIANCE_CHESTPLATE.is(backtank) && !ShadowRadianceChestplate.hasPropeller(chestplate)){
+                    player.sendSystemMessage(CreateQOLLang.translateDirect("armor.ability.no_elytra_or_propeller").withStyle(ChatFormatting.RED),true);
+                }
+            }
+    }
+
+    @Override
+    public PacketTypeProvider getTypeProvider() {
+        return QOLPackets.TOGGLE_FANS_ELYTRA;
+    }
+}

--- a/src/main/java/fr/iglee42/createqualityoflife/registries/QOLPackets.java
+++ b/src/main/java/fr/iglee42/createqualityoflife/registries/QOLPackets.java
@@ -18,6 +18,7 @@ public enum QOLPackets implements BasePacketPayload.PacketTypeProvider {
     TOGGLE_FANS(ToggleFansPacket.class,ToggleFansPacket.STREAM_CODEC),
     TOGGLE_HOVER(ToggleHoverPacket.class, ToggleHoverPacket.STREAM_CODEC),
     TOGGLE_ELYTRA(ToggleElytraPacket.class, ToggleElytraPacket.STREAM_CODEC),
+    TOGGLE_FANS_ELYTRA(ToggleFansElytraPacket.class, ToggleFansElytraPacket.STREAM_CODEC),
     INPUTS_UPDATE(UpdateInputsPacket.class, UpdateInputsPacket.STREAM_CODEC),
     DASH(DashPacket.class, DashPacket.STREAM_CODEC),
     CHANGE_ARMOR_COMPONENT(ChangeItemComponentPacket.class, ChangeItemComponentPacket.STREAM_CODEC),

--- a/src/main/java/fr/iglee42/createqualityoflife/utils/KeyBindManager.java
+++ b/src/main/java/fr/iglee42/createqualityoflife/utils/KeyBindManager.java
@@ -31,6 +31,7 @@ public class KeyBindManager {
     public static KeyMapping FANS_KEY = new KeyMapping("keybind.createqol.shadow_radiance_chestplate_fans", GLFW.GLFW_KEY_Y, "keybind.createqol.category");
     public static KeyMapping HOVER_KEY = new KeyMapping("keybind.createqol.shadow_radiance_chestplate_hover", GLFW.GLFW_KEY_H, "keybind.createqol.category");
     public static KeyMapping ELYTRA_KEY = new KeyMapping("keybind.createqol.shadow_radiance_chestplate_elytra", GLFW.GLFW_KEY_I, "keybind.createqol.category");
+    public static KeyMapping TOGGLE_FANS_ELYTRA_KEY = new KeyMapping("keybind.createqol.shadow_radiance_chestplate_toggle_fans_elytra", -1, "keybind.createqol.category");
     public static KeyMapping OPEN_ARMOR_CONFIG = new KeyMapping("keybind.createqol.open_armor_config", GLFW.GLFW_KEY_C, "keybind.createqol.category");
     public static KeyMapping DASH_KEY = new KeyMapping("keybind.createqol.dash", GLFW.GLFW_KEY_W, "keybind.createqol.category");
 
@@ -105,6 +106,9 @@ public class KeyBindManager {
             }
             if (ELYTRA_KEY.consumeClick()) {
                 PacketDistributor.sendToServer(ToggleElytraPacket.INSTANCE);
+            }
+            if (TOGGLE_FANS_ELYTRA_KEY.consumeClick()) {
+                PacketDistributor.sendToServer(ToggleFansElytraPacket.INSTANCE);
             }
         }
         tickEnd();

--- a/src/main/resources/assets/createqol/lang/en_us.json
+++ b/src/main/resources/assets/createqol/lang/en_us.json
@@ -102,6 +102,7 @@
   "keybind.createqol.shadow_radiance_chestplate_fans": "Toggle Fans",
   "keybind.createqol.shadow_radiance_chestplate_hover": "Toggle Hover",
   "keybind.createqol.shadow_radiance_chestplate_elytra": "Toggle Elytra",
+  "keybind.createqol.shadow_radiance_chestplate_toggle_fans_elytra": "Toggle Fans/Elytra",
   "keybind.createqol.open_armor_config": "Open Armor Config",
   "keybind.createqol.dash": "Dash",
 
@@ -226,6 +227,7 @@
   "createqol.armor.ability.use_fireworks": "Can be used as a boost with the shadow radiance chestplate by keeping pressed the jump key.",
   "createqol.armor.ability.no_propeller": "You can't switch the fan/hover because the chestplate doesn't have a propeller installed.",
   "createqol.armor.ability.no_elytra": "You can't switch the elytra because the chestplate doesn't have elytra installed",
+  "createqol.armor.ability.no_elytra_or_propeller": "You can't switch the elytra/fan because the chestplate doesn't have elytra or propeller installed",
   "createqol.armor.ability.dash_disabled": "Dashing is disabled on this server !",
   "createqol.armor.ability.dash_reloading": "Dashing is reloading, please wait!",
 

--- a/src/main/resources/assets/createqol/lang/ja_jp.json
+++ b/src/main/resources/assets/createqol/lang/ja_jp.json
@@ -101,6 +101,7 @@
   "keybind.createqol.shadow_radiance_chestplate_fans": "ファン切替",
   "keybind.createqol.shadow_radiance_chestplate_hover": "ホバー切替",
   "keybind.createqol.shadow_radiance_chestplate_elytra": "エリトラ切替",
+  "keybind.createqol.shadow_radiance_chestplate_toggle_fans_elytra": "ファン/エリトラ切替",
   "keybind.createqol.open_armor_config": "防具設定を開く",
   "keybind.createqol.dash": "ダッシュ",
 
@@ -225,6 +226,7 @@
   "createqol.armor.ability.use_fireworks": "シャドウラディアンスのチェストプレート装着時、ジャンプキー長押しでブーストとして使用可能",
   "createqol.armor.ability.no_propeller": "チェストプレートにプロペラがないためファン/ホバー切り替えができません",
   "createqol.armor.ability.no_elytra": "チェストプレートにエリトラがないためエリトラ切り替えができません",
+  "createqol.armor.ability.no_elytra_or_propeller": "チェストプレートにエリトラもプロペラもないため、エリトラ/ファンの切り替えができません",
   "createqol.armor.ability.dash_disabled": "このサーバーではダッシュが無効化されています!",
   "createqol.armor.ability.dash_reloading": "ダッシュはリロード中です。お待ちください！",
 

--- a/src/main/resources/assets/createqol/lang/ru_ru.json
+++ b/src/main/resources/assets/createqol/lang/ru_ru.json
@@ -103,6 +103,7 @@
   "keybind.createqol.shadow_radiance_chestplate_fans": "Режим пропеллерной тяги",
   "keybind.createqol.shadow_radiance_chestplate_hover": "Режим парения",
   "keybind.createqol.shadow_radiance_chestplate_elytra": "Режим полёта",
+  "keybind.createqol.shadow_radiance_chestplate_toggle_fans_elytra": "Переключить режимы полёта",
   "keybind.createqol.open_armor_config": "Открыть конфигурацию брони",
   "keybind.createqol.dash": "Рывок",
 
@@ -227,6 +228,7 @@
   "createqol.ability.armor.use_fireworks": "Находясь в инвентаре, может быть использован для ускорения полёта, когда надет нагрудник из пост-хроматического сплава, оснащённый элитрами — для этого зажмите [Пробел], находясь в режиме полёта.",
   "createqol.ability.armor.no_propeller": "Режимы пропеллерной тяги и парения недоступны: баллон не оснащён пропеллером",
   "createqol.ability.armor.no_elytra": "Режим полёта недоступен: баллон не оснащён элитрами",
+  "createqol.armor.ability.no_elytra_or_propeller": "Невозможно переключить режимы полёта, так как нагрудник не оснащён ни элитрами, ни пропеллером",
   "createqol.ability.armor.dash_disabled": "Функция рывка запрещена настройками мира/сервера",
   "createqol.ability.armor.dash_reloading": "Рывок перезаряжается...",
 


### PR DESCRIPTION
Added a toggle between fans and elytra (see #45).  
Additionally, introduced a `changelog.md` file to track future changes, similar to the approach used in the main Create mod:  
https://raw.githubusercontent.com/Creators-of-Create/Create/refs/heads/mc1.20.1/dev/changelog.md
