### PR TITLE
Conduct language-related QoL improvements

### DIFF
--- a/src/main/java/fr/iglee42/createqualityoflife/client/screens/tabs/AnimationTab.java
+++ b/src/main/java/fr/iglee42/createqualityoflife/client/screens/tabs/AnimationTab.java
@@ -39,8 +39,8 @@ public class AnimationTab extends StatueTab {
     public static final int REVERT_X = 22;
     public static final int COPY_ALL_X = 44;
 
-    private static final List<Component> LOOP_TOOLTIPS = List.of(CreateLang.translateDirect("schedule.loop"),CreateLang.translateDirect("gui.schematicannon.optionDisabled").withStyle(ChatFormatting.RED));
-    private static final List<Component> ON_LOOP_TOOLTIPS = List.of(CreateLang.translateDirect("schedule.loop"),CreateLang.translateDirect("gui.schematicannon.optionEnabled").withStyle(ChatFormatting.GREEN));
+    private static final List<Component> LOOP_TOOLTIPS = List.of(CreateQOLLang.translateDirect("statue.animation.loop"),CreateLang.translateDirect("gui.schematicannon.optionDisabled").withStyle(ChatFormatting.RED));
+    private static final List<Component> ON_LOOP_TOOLTIPS = List.of(CreateQOLLang.translateDirect("statue.animation.loop"),CreateLang.translateDirect("gui.schematicannon.optionEnabled").withStyle(ChatFormatting.GREEN));
     private static final List<Component> REVERSE_TOOLTIPS = List.of(CreateQOLLang.translateDirect("statue.animation.revert"),CreateLang.translateDirect("gui.schematicannon.optionDisabled").withStyle(ChatFormatting.RED),CreateQOLLang.translateDirect("statue.animation.revert_1"),CreateQOLLang.translateDirect("statue.animation.revert_2"));
     private static final List<Component> ON_REVERSE_TOOLTIPS = List.of(CreateQOLLang.translateDirect("statue.animation.revert"),CreateLang.translateDirect("gui.schematicannon.optionEnabled").withStyle(ChatFormatting.GREEN),CreateQOLLang.translateDirect("statue.animation.revert_1"),CreateQOLLang.translateDirect("statue.animation.revert_2"));
     private static final List<Component> COPY_ALL_TOOLTIPS = List.of(CreateQOLLang.translateDirect("statue.animation.copy_all"),CreateQOLLang.translateDirect("statue.animation.copy_all_1"),CreateQOLLang.translateDirect("statue.animation.copy_all_2"));

--- a/src/main/java/fr/iglee42/createqualityoflife/compat/jei/BlazeBurnerLiquidCategory.java
+++ b/src/main/java/fr/iglee42/createqualityoflife/compat/jei/BlazeBurnerLiquidCategory.java
@@ -46,9 +46,11 @@ public class BlazeBurnerLiquidCategory extends CreateRecipeCategory<BlazeBurnerL
 
 		if (recipe.getFluidIngredients().get(0).getFluids().length > 0 && recipe.getFluidIngredients().get(0).getFluids()[0] != null) {
 			LiquidBlazeBurnerManager.LiquidEntry entry = LiquidBlazeBurnerManager.BLAZE_BURNER_LIQUIDS.get(recipe.getFluidIngredients().get(0).getFluids()[0].getFluid() );
-			int time =  (entry.burnTime() * entry.consumption() * 1000 / 20);
+			int time = (entry.burnTime() * entry.consumption() * 1000 / 20);
+            Component burnerLevel = Component.translatable("createqol.recipe.blaze_burner_liquids.burner_level."
+                    + ((recipe.getBurnerLevel().name().equalsIgnoreCase("seething")) ? "superheat" : "heat"));
 
-			graphics.drawCenteredString(Minecraft.getInstance().font,Component.literal("1 ").append(Component.translatable("item.minecraft.bucket")).append(Component.literal(" = " + formatDuration(time))), 94,60,0xffffff);
+			graphics.drawCenteredString(Minecraft.getInstance().font, Component.translatable("createqol.recipe.blaze_burner_liquids.hint", formatDuration(time), burnerLevel), 94,60,0xffffff);
 
 		}
 		//matrixStack.translate(74, 51, 100);
@@ -62,13 +64,13 @@ public class BlazeBurnerLiquidCategory extends CreateRecipeCategory<BlazeBurnerL
 		StringBuilder result = new StringBuilder();
 
 		if (hours > 0) {
-			result.append(hours).append("h ");
+			result.append(Component.translatable("createqol.recipe.blaze_burner_liquids.duration.hours", hours).getString());
 		}
 		if (minutes > 0) {
-			result.append(minutes).append("min ");
+			result.append(Component.translatable("createqol.recipe.blaze_burner_liquids.duration.minutes", minutes).getString());
 		}
 		if (seconds > 0 || result.isEmpty()) { // always show at least seconds
-			result.append(seconds).append("s");
+			result.append(Component.translatable("createqol.recipe.blaze_burner_liquids.duration.seconds", seconds).getString());
 		}
 
 		return result.toString().trim();

--- a/src/main/java/fr/iglee42/createqualityoflife/items/armors/RefinedRadianceChestplate.java
+++ b/src/main/java/fr/iglee42/createqualityoflife/items/armors/RefinedRadianceChestplate.java
@@ -99,15 +99,15 @@ public class RefinedRadianceChestplate extends BacktankItem.Layered implements Q
 
     @Override
     public void appendHoverText(ItemStack stack, @Nullable TooltipContext p_41422_, List<Component> components, TooltipFlag p_41424_) {
-        String airTooltip = " (" + Component.translatable(CreateQOLConfigs.server().equipments.useAir.get() ? "createqol.tooltip.use_air.powering" : "createqol.tooltip.use_air.breathing").getString() + ")";
+        String airTooltip = CreateQOLConfigs.server().equipments.useAir.get() ? "createqol.tooltip.use_air.powering" : "createqol.tooltip.use_air.breathing";
         if (!stack.getOrDefault(QOLDataComponents.ITEM_TOOLTIPS, ItemTooltips.DEFAULT).isEnable(ItemTooltips.Tooltip.OPTIONS)) return;
         components.add(Component.translatable("createqol.ability.armor.toggle_message", Component.translatable("createqol.ability.armor.air").getString())
                 .withStyle(ChatFormatting.GOLD)
-                .append(Component.literal(String.valueOf(BacktankUtil.getAir(stack)))
-                        .withStyle(ChatFormatting.YELLOW))
-                .append(Component.literal("/" + BacktankUtil.maxAir(stack))
-                        .withStyle(ChatFormatting.GOLD))
-                .append(Component.literal(airTooltip)
+                .append(Component.translatable(airTooltip,
+                                Component.literal("" + BacktankUtil.getAir(stack))
+                                        .withStyle(ChatFormatting.YELLOW),
+                                Component.literal("" + BacktankUtil.maxAir(stack))
+                                        .withStyle(ChatFormatting.YELLOW))
                         .withStyle(ChatFormatting.GOLD)));
         components.add(Component.translatable("createqol.ability.armor.toggle_message", Component.translatable("createqol.ability.armor.elytra").getString())
                 .withStyle(ChatFormatting.GOLD)

--- a/src/main/java/fr/iglee42/createqualityoflife/items/armors/ShadowRadianceChestplate.java
+++ b/src/main/java/fr/iglee42/createqualityoflife/items/armors/ShadowRadianceChestplate.java
@@ -190,16 +190,16 @@ public class ShadowRadianceChestplate extends BacktankItem.Layered implements QO
 
     @Override
     public void appendHoverText(ItemStack stack, @Nullable TooltipContext p_41422_, List<Component> components, TooltipFlag p_41424_) {
-        String airTooltip = " (" + Component.translatable(CreateQOLConfigs.server().equipments.useAir.get() ? "createqol.tooltip.use_air.powering" : "createqol.tooltip.use_air.breathing").getString() + ")";
+        String airTooltip = CreateQOLConfigs.server().equipments.useAir.get() ? "createqol.tooltip.use_air.powering" : "createqol.tooltip.use_air.breathing";
         if (!stack.getOrDefault(QOLDataComponents.ITEM_TOOLTIPS, ItemTooltips.DEFAULT).isEnable(ItemTooltips.Tooltip.OPTIONS)) return;
         components.add(Component.translatable("createqol.ability.armor.toggle_message", Component.translatable("createqol.ability.armor.air").getString())
                 .withStyle(ChatFormatting.GOLD)
-                .append(Component.literal(String.valueOf(BacktankUtil.getAir(stack)))
-                        .withStyle(ChatFormatting.YELLOW))
-                .append(Component.literal("/"+BacktankUtil.maxAir(stack))
-                        .withStyle(ChatFormatting.GOLD)
-                .append(Component.literal(airTooltip)
-                        .withStyle(ChatFormatting.GOLD))));
+                .append(Component.translatable(airTooltip,
+                                Component.literal("" + BacktankUtil.getAir(stack))
+                                        .withStyle(ChatFormatting.YELLOW),
+                                Component.literal("" + BacktankUtil.maxAir(stack))
+                                        .withStyle(ChatFormatting.YELLOW))
+                        .withStyle(ChatFormatting.GOLD)));
         components.add(Component.translatable("createqol.ability.armor.toggle_message", Component.translatable("createqol.ability.armor.effect").getString())
                 .withStyle(ChatFormatting.GOLD)
                 .append(Component.translatable(providedEffect(stack).value().getDescriptionId()).withStyle(ChatFormatting.YELLOW)));

--- a/src/main/java/fr/iglee42/createqualityoflife/items/armors/ShadowSteelChestplate.java
+++ b/src/main/java/fr/iglee42/createqualityoflife/items/armors/ShadowSteelChestplate.java
@@ -60,16 +60,16 @@ public class ShadowSteelChestplate extends BacktankItem.Layered implements QOLCo
 
     @Override
     public void appendHoverText(ItemStack stack, @Nullable TooltipContext p_41422_, List<Component> components, TooltipFlag p_41424_) {
-        String airTooltip = " (" + Component.translatable(CreateQOLConfigs.server().equipments.useAir.get() ? "createqol.tooltip.use_air.powering" : "createqol.tooltip.use_air.breathing").getString() + ")";
+        String airTooltip = CreateQOLConfigs.server().equipments.useAir.get() ? "createqol.tooltip.use_air.powering" : "createqol.tooltip.use_air.breathing";
         if (!stack.getOrDefault(QOLDataComponents.ITEM_TOOLTIPS, ItemTooltips.DEFAULT).isEnable(ItemTooltips.Tooltip.OPTIONS)) return;
         components.add(Component.translatable("createqol.ability.armor.toggle_message", Component.translatable("createqol.ability.armor.air").getString())
                 .withStyle(ChatFormatting.GOLD)
-                .append(Component.literal(String.valueOf(BacktankUtil.getAir(stack)))
-                        .withStyle(ChatFormatting.YELLOW))
-                .append(Component.literal("/" + BacktankUtil.maxAir(stack))
-                        .withStyle(ChatFormatting.GOLD)
-                .append(Component.literal(airTooltip)
-                        .withStyle(ChatFormatting.GOLD))));
+                .append(Component.translatable(airTooltip,
+                                Component.literal("" + BacktankUtil.getAir(stack))
+                                        .withStyle(ChatFormatting.YELLOW),
+                                Component.literal("" + BacktankUtil.maxAir(stack))
+                                        .withStyle(ChatFormatting.YELLOW))
+                        .withStyle(ChatFormatting.GOLD)));
         components.add(Component.translatable("createqol.ability.armor.toggle_message", Component.translatable("createqol.ability.armor.dash").getString())
                 .withStyle(ChatFormatting.GOLD)
                 .append(QOLConfigurableItem.cooldownState(CreateQOLConfigs.server().equipments.armors.dashAllowed.get(),

--- a/src/main/java/fr/iglee42/createqualityoflife/packets/ToggleArmorEffectPacket.java
+++ b/src/main/java/fr/iglee42/createqualityoflife/packets/ToggleArmorEffectPacket.java
@@ -34,8 +34,11 @@ public record ToggleArmorEffectPacket(EquipmentSlot slot) implements Serverbound
             if (it.providedEffect(stack) == null) return;
             boolean enable = !stack.getOrDefault(QOLDataComponents.ARMOR_EFFECT,true);
             stack.set(QOLDataComponents.ARMOR_EFFECT,enable);
-            player.displayClientMessage(Component.translatable(stack.getDescriptionId()).append(Component.literal( " Effect : ").append(QOLConfigurableItem.chooseState(true,true,enable,false,true))).withStyle(enable ? ChatFormatting.GREEN : ChatFormatting.RED), true);
-
+            player.displayClientMessage(Component.translatable("createqol.ability.armor.effect_toggle_message",
+                                    Component.translatable(stack.getDescriptionId()))
+                    .withStyle(enable ? ChatFormatting.GREEN : ChatFormatting.RED)
+                    .append(QOLConfigurableItem.chooseState(true ,true, enable, false, true)),
+                    true);
         }
     }
 

--- a/src/main/java/fr/iglee42/createqualityoflife/registries/QOLItems.java
+++ b/src/main/java/fr/iglee42/createqualityoflife/registries/QOLItems.java
@@ -87,9 +87,9 @@ public class QOLItems {
                     .register();
 
     public static final ItemEntry<SmithingTemplateItem> SHADOW_RADIANCE_UPGRADE_SMITHING_TEMPLATE = REGISTRATE.item("shadow_radiance_upgrade_smithing_template",p->new SmithingTemplateItem(
-            Component.translatable(Util.makeDescriptionId("item", CreateQOL.asResource("smithing_template.shadow_radiance_upgrade.applies_to"))).withStyle(ChatFormatting.GRAY),
-            Component.translatable(Util.makeDescriptionId("item", CreateQOL.asResource("smithing_template.shadow_radiance_upgrade.ingredients"))).withStyle(ChatFormatting.GRAY),
-            Component.translatable(Util.makeDescriptionId("upgrade", CreateQOL.asResource("shadow_radiance_upgrade"))).withStyle(ChatFormatting.BLUE),
+            Component.translatable(Util.makeDescriptionId("item", CreateQOL.asResource("smithing_template.shadow_radiance_upgrade.applies_to"))).withStyle(ChatFormatting.BLUE),
+            Component.translatable(Util.makeDescriptionId("item", CreateQOL.asResource("smithing_template.shadow_radiance_upgrade.ingredients"))).withStyle(ChatFormatting.BLUE),
+            Component.translatable(Util.makeDescriptionId("upgrade", CreateQOL.asResource("shadow_radiance_upgrade"))).withStyle(ChatFormatting.GRAY),
             Component.translatable(Util.makeDescriptionId("item", CreateQOL.asResource("smithing_template.shadow_radiance_upgrade.base_slot_description"))),
             Component.translatable(Util.makeDescriptionId("item", CreateQOL.asResource("smithing_template.shadow_radiance_upgrade.additions_slot_description"))),
             createUpgradeIconList(),

--- a/src/main/resources/assets/createqol/lang/en_us.json
+++ b/src/main/resources/assets/createqol/lang/en_us.json
@@ -61,10 +61,7 @@
   "tag.item.c.buckets.superheated_lava": "Superheated Lava Buckets",
   "tag.fluid.c.superheated_lava": "Superheated Lava",
 
-
-
   "fluid.createqol.superheated_lava": "Superheated Lava",
-
 
   "create.options.inventory_linker.label": "Inventory Link Mode",
   "options.inventory_linker.inventory": "Inventory",
@@ -128,6 +125,12 @@
   "keybind.createqol.boots_effect": "Toggle Boots Effect",
 
   "createqol.recipe.blaze_burner_liquids": "Blaze Burner Liquid Fuels",
+  "createqol.recipe.blaze_burner_liquids.hint": "1 Bucket = %s of %s",
+  "createqol.recipe.blaze_burner_liquids.burner_level.heat": "heat",
+  "createqol.recipe.blaze_burner_liquids.burner_level.superheat": "superheat",
+  "createqol.recipe.blaze_burner_liquids.duration.hours": "%sh ",
+  "createqol.recipe.blaze_burner_liquids.duration.minutes": "%sm ",
+  "createqol.recipe.blaze_burner_liquids.duration.seconds": "%ss",
 
   "entity.createqol.statue": "Statue",
 
@@ -218,6 +221,7 @@
   "createqol.statue.animation.create": "Click on the button to create an animation. Statues can only store 1 animation.",
   "createqol.statue.animation.frame.create": "Click on the button to create a frame. 1 frame corresponds to 1 tick of the animation. Interpolation between frame is automatically made.",
 
+  "createqol.statue.animation.loop": "Loop",
   "createqol.statue.animation.revert": "Revert",
   "createqol.statue.animation.revert_1": "Should the animation go backwards",
   "createqol.statue.animation.revert_2": "when it is at the end",
@@ -247,13 +251,13 @@
   "createqol.armor.ability.dash_disabled": "Dashing is disabled on this server !",
   "createqol.armor.ability.dash_reloading": "Dashing is reloading, please wait!",
 
-  "createqol.ability.use_air": "Use Air",
-  "createqol.tooltip.use_air.powering": "Powering equipment with air",
-  "createqol.tooltip.use_air.breathing": "Underwater breathing only",
+  "createqol.tooltip.use_air.powering": "%s / %s (Powering equipment with air)",
+  "createqol.tooltip.use_air.breathing": "%s / %s (Underwater breathing only)",
 
   "createqol.ability.armor.disabled": "%s is disabled by the config",
   "createqol.ability.armor.unavailable": "%1$s can't be enabled while the %2$s is enabled",
   "createqol.ability.armor.reloading": "%s is reloading, please wait!",
+  "createqol.ability.armor.effect_toggle_message": "%s Effect : ",
   "createqol.ability.armor.toggle_message": "%s : ",
 
   "createqol.ability.tool.disabled": "%s ability is disabled by the config",


### PR DESCRIPTION
Long time no see! A new batch of dehardcoding & template-ifying strings was inevitable.

- Added separate string for Loop setting in the Animation tab of Statue sreen;
- Template-ified the Blaze Burher heat time hint;
- Template-ified the postfix-inclusive Air indicator in Chestplates' tooltips;
- Template-ified the Effect toggle message;
- Brought the Smithing Template tooltip coloring to the vanilla standard.

###### P.S. Also removed the unused `"createqol.ability.use_air"` string.